### PR TITLE
UUID 대신 멤버 정보 주입

### DIFF
--- a/src/main/java/com/nhnacademy/marketgg/server/aop/AuthInjectAspect.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/aop/AuthInjectAspect.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nhnacademy.marketgg.server.dto.AuthInfo;
-import com.nhnacademy.marketgg.server.dto.response.common.CommonResponse;
 import com.nhnacademy.marketgg.server.dto.response.common.ErrorEntity;
 import com.nhnacademy.marketgg.server.dto.response.common.SingleResponse;
 import java.util.Arrays;
@@ -37,7 +36,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  */
 @Slf4j
 @Aspect
-@Order(20)
+@Order(40)
 @Component
 @RequiredArgsConstructor
 public class AuthInjectAspect {

--- a/src/main/java/com/nhnacademy/marketgg/server/aop/MemberInfoAspect.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/aop/MemberInfoAspect.java
@@ -1,0 +1,46 @@
+package com.nhnacademy.marketgg.server.aop;
+
+import com.nhnacademy.marketgg.server.dto.MemberInfo;
+import com.nhnacademy.marketgg.server.exception.member.MemberNotFoundException;
+import com.nhnacademy.marketgg.server.repository.member.MemberRepository;
+import java.util.Arrays;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Order(30)
+@Component
+@RequiredArgsConstructor
+public class MemberInfoAspect {
+
+    private final MemberRepository memberRepository;
+
+    @Around("execution(* com.nhnacademy.marketgg.server.controller.*.*(.., com.nhnacademy.marketgg.server.dto.MemberInfo, ..))")
+    public Object getMemberInfo(ProceedingJoinPoint pjp) throws Throwable {
+        log.info("Method: {}", pjp.getSignature().getName());
+
+        HttpServletRequest request = AspectUtils.getRequest();
+        String uuid = request.getHeader(AspectUtils.AUTH_ID);
+
+        MemberInfo memberInfo = memberRepository.findMemberInfoByUuid(uuid)
+                                                .orElseThrow(MemberNotFoundException::new);
+
+        Object[] args = Arrays.stream(pjp.getArgs())
+                              .map(arg -> {
+                                  if (arg instanceof MemberInfo) {
+                                      arg = memberInfo;
+                                  }
+                                  return arg;
+                              }).toArray();
+
+        return pjp.proceed(args);
+    }
+
+}

--- a/src/main/java/com/nhnacademy/marketgg/server/controller/MemberController.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/controller/MemberController.java
@@ -108,7 +108,7 @@ public class MemberController {
      */
     @RoleCheck(accessLevel = Role.ROLE_USER)
     @GetMapping
-    public ResponseEntity<? extends CommonResponse> retrieveMember(HttpServletRequest request) {
+    public ResponseEntity<CommonResponse> retrieveMember(HttpServletRequest request) {
         String uuid = request.getHeader("AUTH-ID");
         MemberResponse memberResponse = memberService.retrieveMember(uuid);
 

--- a/src/main/java/com/nhnacademy/marketgg/server/dto/MemberInfo.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/dto/MemberInfo.java
@@ -1,0 +1,19 @@
+package com.nhnacademy.marketgg.server.dto;
+
+import com.nhnacademy.marketgg.server.entity.MemberGrade;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MemberInfo {
+
+    private final Long id;
+    private final MemberGrade memberGrade;
+    private final Character gender;
+    private final LocalDate birthDate;
+    private final LocalDateTime ggpassUpdatedAt;
+
+}

--- a/src/main/java/com/nhnacademy/marketgg/server/repository/member/MemberRepositoryCustom.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/repository/member/MemberRepositoryCustom.java
@@ -1,7 +1,12 @@
 package com.nhnacademy.marketgg.server.repository.member;
 
+import com.nhnacademy.marketgg.server.dto.MemberInfo;
+import java.util.Optional;
 import org.springframework.data.repository.NoRepositoryBean;
 
 @NoRepositoryBean
 public interface MemberRepositoryCustom {
+
+    Optional<MemberInfo> findMemberInfoByUuid(String uuid);
+
 }

--- a/src/main/java/com/nhnacademy/marketgg/server/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/repository/member/MemberRepositoryImpl.java
@@ -1,12 +1,29 @@
 package com.nhnacademy.marketgg.server.repository.member;
 
+import com.nhnacademy.marketgg.server.dto.MemberInfo;
 import com.nhnacademy.marketgg.server.entity.Member;
+import com.nhnacademy.marketgg.server.entity.QMember;
+import com.querydsl.core.types.Projections;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
 public class MemberRepositoryImpl extends QuerydslRepositorySupport implements MemberRepositoryCustom {
 
     public MemberRepositoryImpl() {
         super(Member.class);
+    }
+
+    @Override
+    public Optional<MemberInfo> findMemberInfoByUuid(String uuid) {
+        QMember member = QMember.member;
+
+        MemberInfo memberInfo = from(member)
+            .select(Projections.constructor(MemberInfo.class,
+                member.id, member.memberGrade, member.gender, member.birthDate, member.ggpassUpdatedAt))
+            .where(member.uuid.eq(uuid))
+            .fetchOne();
+
+        return Optional.ofNullable(memberInfo);
     }
 
 }


### PR DESCRIPTION
## 개요
- ·
- AOP 를 이용하여 멤버 주입

## 작업사항
- UUID 보다 Member 정보를 전달하는 것이 좋다는 의견이 있어 추가한 기능입니다.
- 어노테이션 없이 컨트롤러에서 `MemberInfo` 클래스 파라미터에 선언해주시면 사용 가능합니다.

## 기타사항
- `@UUID` 삭제 논의 필요
