### PR TITLE
Swagger 프레임워크 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.9</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-config-client</artifactId>
         </dependency>
@@ -128,7 +134,6 @@
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
         </dependency>
-
 
     </dependencies>
 

--- a/src/main/java/com/nhnacademy/marketgg/server/config/InterceptorConfig.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/config/InterceptorConfig.java
@@ -4,8 +4,17 @@ import com.nhnacademy.marketgg.server.interceptor.AdminInterceptor;
 import com.nhnacademy.marketgg.server.interceptor.AuthInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * 컨트롤러의 요청 및 응답을 가로채서 관리자 및 인증 인터셉터 기능을 수행하고, API 문서화(Swagger)를 위한 자원을 등록합니다.
+ *
+ * @author 윤동열
+ * @author 이제훈
+ * @version 1.0.0
+ * @since 1.0.0
+ */
 @Configuration
 public class InterceptorConfig implements WebMvcConfigurer {
 
@@ -13,7 +22,16 @@ public class InterceptorConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AdminInterceptor())
                 .addPathPatterns("/admin/**");
-        registry.addInterceptor(new AuthInterceptor());
+        registry.addInterceptor(new AuthInterceptor())
+                .excludePathPatterns("/swagger-resources/**", "/webjars/**", "/v2/**", "/swagger-ui/**", "/api/**");
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/swagger-ui/**")
+                .addResourceLocations("classpath:/META-INF/resources/");
+        registry.addResourceHandler("**/webjars/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/");
     }
 
 }

--- a/src/main/java/com/nhnacademy/marketgg/server/config/SwaggerConfig.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/config/SwaggerConfig.java
@@ -1,0 +1,81 @@
+package com.nhnacademy.marketgg.server.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.GroupedOpenApi;
+import org.springdoc.core.customizers.OpenApiCustomiser;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * Open API Specification(OAS) 를 위한 Swagger 프레임워크 관련 설정 클래스입니다.
+ *
+ * @author 이제훈
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+@Profile("swagger")
+@OpenAPIDefinition(info = @Info(title = "Market GG SHOP-SERVICE",
+                                description = "Market GG Shop 서비스에 대한 API 가이드입니다.",
+                                contact = @Contact(name = "Contact Me",
+                                                   url = "https://github.com/nhn-on7",
+                                                   email = "on7.marketgg@gmail.com"),
+                                license = @License(name = "Apache License 2.0",
+                                                   url = "https://www.apache.org/licenses/LICENSE-2.0"),
+                                version = "v1.0.0"))
+@Configuration
+public class SwaggerConfig {
+
+    /**
+     * 그룹핑하고자 하는 API 경로를 지정하고 빈으로 등록합니다.
+     * 예를 들어, paths 지역 변수에 "/admin/**" 로 초기화하는 경우 "/admin" 으로 시작하는 경로를 {GROUP_NAME} API 로 그룹핑합니다.
+     *
+     * @return 그룹핑된 Open API 인스턴스
+     */
+    @Bean
+    public GroupedOpenApi adminGroupedOpenApi() {
+        return GroupedOpenApi.builder()
+                             .group("관리자 API Specs")
+                             .pathsToMatch("/admin/**")
+                             .addOpenApiCustomiser(this.openApiCustomizer())
+                             .build();
+    }
+
+    /**
+     * 회원과 관련된 API 경로 목록을 그룹핑하고 빈으로 등록합니다.
+     *
+     * @return 회원 API 로 그룹핑된 Open API 인스턴스
+     */
+    @Bean
+    public GroupedOpenApi membersGroupedOpenApi() {
+        return GroupedOpenApi.builder()
+                             .group("회원 API Specs")
+                             .pathsToMatch("/members/**")
+                             .addOpenApiCustomiser(this.openApiCustomizer())
+                             .build();
+    }
+
+    /**
+     * Swagger 를 통해 API 호출 시 보안 설정과 관련된 부분에 대해 전역 설정이 가능합니다.
+     * 해당 메서드는 header 에 JWT 를 주입합니다.
+     *
+     * @return OpenApiCustomizer
+     */
+    public OpenApiCustomiser openApiCustomizer() {
+        return openApi -> openApi.addSecurityItem(new SecurityRequirement().addList("jwt"))
+                                 .getComponents()
+                                 .addSecuritySchemes("jwt",
+                                                     new SecurityScheme().name(HttpHeaders.AUTHORIZATION)
+                                                                         .type(SecurityScheme.Type.HTTP)
+                                                                         .in(SecurityScheme.In.HEADER)
+                                                                         .bearerFormat("JWT")
+                                                                         .scheme("bearer"));
+    }
+
+}


### PR DESCRIPTION
## 개요

Closes #233

## 작업 사항

- [x] springdoc 의존성 추가
- [x] 리소스 경로 커스터마이징
- [x] Swagger 구성 ⭐

## Swagger UI 접속 방법

### 프로파일에 `swagger` 추가 (로컬에서만 적용)

### Swagger UI 접속 URL

```text
http://localhost:7080/api/index.html
```

### *springfox* -> *springdoc* 도입

도입 근거는 크게 다음과 같습니다.

1. 사용법이 비교적 단순하다.

1. 버그에 대한 대응과 라이브러리 업데이트가 지속 가능한 상태인가?

    - 오늘자 기준으로 `springfox` 는 2020년이 최신 버전이며, `springdoc` 은 2022년 8월이 최신 버전
    - [Swagger. Springfox-Swagger 그리고 Springdoc](https://junho85.pe.kr/1583)

1. `springfox` 는 찬밥 신세, `springdoc` 은 신흥 세력

    이와 관련된 열띤 [토론](https://stackoverflow.com/questions/72479827/are-there-any-advantages-of-using-migrating-to-springdoc-openapi-from-springfox)의 장을 참고바랍니다.

1. *v3.0.0* 은 애노테이션 및 매개변수 사용법이 많이 달라져 `springfox` 의 장점인 레퍼런스가 풍부한 것이 무의미해짐

```java
// 애노테이션 변경
@ApiParam -> @Parameter	
@ApiOperation -> @Operation
@Api -> @Tag
@ApiImplicitParams -> @Parameters
@ApiImplicitParam -> @Parameter
@ApiIgnore -> @Parameter(hidden = true) or @operation(hidden = true) or @hidden
@apimodel -> @Schema
@ApiModelProperty -> @Schema

// 매개변수 변경
value = xxx -> description = xxx
tags = xxx -> name = xxx
```

애노테이션 및 매개변수 변경 사항은 관련 [링크](https://velog.io/@hyejinjeong9999/springdoc%EC%9C%BC%EB%A1%9C-swagger3-%EB%8F%84%EC%9E%85)를 참고바랍니다.

## 참조 링크

- [Swagger, 다 같은 놈이 아니었다.](https://velog.io/@ychxexn/Swagger-%EB%8B%A4-%EA%B0%99%EC%9D%80-%EB%86%88%EC%9D%B4-%EC%95%84%EB%8B%88%EC%97%88%EB%8B%A4.-Springfox-vs-Springdoc)
- [springdoc으로 swagger3 도입](https://velog.io/@hyejinjeong9999/springdoc%EC%9C%BC%EB%A1%9C-swagger3-%EB%8F%84%EC%9E%85)