### PR TITLE
결제 테스트 코드 작성

### DIFF
--- a/src/main/java/com/nhnacademy/marketgg/server/aop/AuthInfoAspect.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/aop/AuthInfoAspect.java
@@ -79,7 +79,9 @@ public class AuthInfoAspect {
             restTemplate.exchange(gateway + "/auth/v1/members/info", GET, httpEntity,
                                   new ParameterizedTypeReference<>() {
                                   });
+
         this.validCheck(exchange);
+
         AuthInfo authInfo = Objects.requireNonNull(exchange.getBody()).getData();
         log.info("AuthInfo = {}", authInfo);
 
@@ -101,4 +103,5 @@ public class AuthInfoAspect {
             throw new IllegalArgumentException(error.getMessage());
         }
     }
+
 }

--- a/src/main/java/com/nhnacademy/marketgg/server/controller/payment/PaymentController.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/controller/payment/PaymentController.java
@@ -100,15 +100,15 @@ public class PaymentController {
      * @return 발급한 가상계좌 데이터를 포함한 결과 데이터
      */
     @PostMapping("/payments/virtual-accounts")
-    public ResponseEntity<ShopResult<PaymentResponse>> createVirtualAccounts(@RequestBody @Valid final
+    public ResponseEntity<ShopResult<String>> createVirtualAccounts(@RequestBody @Valid final
                                                                              VirtualAccountCreateRequest request) {
         log.info("createVirtualAccounts: {}", request);
 
-        PaymentResponse data = paymentService.createVirtualAccounts(request);
+        paymentService.createVirtualAccounts(request);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                              .contentType(MediaType.APPLICATION_JSON)
-                             .body(ShopResult.successWith(data));
+                             .body(ShopResult.successWithDefaultMessage());
     }
 
     /**
@@ -132,7 +132,9 @@ public class PaymentController {
 
         paymentService.putMoneyInVirtualAccount(request);
 
-        return null;
+        return ResponseEntity.status(HttpStatus.OK)
+                             .contentType(MediaType.APPLICATION_JSON)
+                             .body(ShopResult.successWithDefaultMessage());
     }
 
     /**

--- a/src/main/java/com/nhnacademy/marketgg/server/dto/ErrorEntity.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/dto/ErrorEntity.java
@@ -26,4 +26,3 @@ public class ErrorEntity {
     private final String message;
 
 }
-

--- a/src/main/java/com/nhnacademy/marketgg/server/dto/payment/PaymentResponse.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/dto/payment/PaymentResponse.java
@@ -12,6 +12,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 /**
  * 결제 요청에 대해 결제대행사로부터 전달받는 응답 데이터 클래스입니다.
@@ -40,20 +41,26 @@ public class PaymentResponse {
     @Size(max = 100)
     private String orderName;
 
+    @Schema(title = "결제 처리 상태", description = "결제 처리 상태값을 가질 수 있습니다.", example = "DONE")
     @NotBlank
     @Size(max = 20)
     private String status;
 
+    @Schema(title = "거래키", description = "결제 한 건에 대한 승인 및 취소 거래를 구분하는데 사용합니다.",
+            example = "0A25AEB83EB828C7CBDB3E0C97834557")
     @NotBlank
     @Size(max = 64)
     private String transactionKey;
 
+    @Schema(title = "결제 요청일자", description = "결제 요청이 일어난 날짜와 시간 정보입니다.", example = "2022-01-01T00:00:00+09:00")
     @NotNull
     private String requestedAt;
 
+    @Schema(title = "결제 승인일자", description = "결제 승인이 일어난 날짜와 시간 정보입니다.", example = "2022-01-01T00:00:00+09:00")
     @NotNull
     private String approvedAt;
 
+    @Schema(title = "카드", description = "카드로 결제하면 제공되는 카드 관련 정보입니다..")
     private CardPaymentResult card;
 
     private VirtualAccountPaymentResult virtualAccount;
@@ -82,8 +89,6 @@ public class PaymentResponse {
 
     private String failure;
 
-    private boolean isPartialCancelable;
-
     @NotNull
     private Receipt receipt;
 
@@ -91,9 +96,11 @@ public class PaymentResponse {
     @Size(min = 1, max = 3)
     private String currency;
 
+    @Schema(title = "최종 결제 금액", description = "총 결제 금액입니다.", example = "75600")
     @NotNull
     private Long totalAmount;
 
+    @Schema(title = "잔액", description = "취소할 수 있는 금액(잔고)입니다.", example = "100")
     @NotNull
     private Long balanceAmount;
 
@@ -106,6 +113,7 @@ public class PaymentResponse {
     @NotNull
     private Long taxFreeAmount;
 
+    @Schema(title = "결제 수단", description = "결제할 때 사용한 결제 수단입니다.", example = "카드")
     @NotBlank
     @Size(min = 6, max = 21)
     private String method;

--- a/src/main/java/com/nhnacademy/marketgg/server/dto/response/order/OrderToPayment.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/dto/response/order/OrderToPayment.java
@@ -1,7 +1,6 @@
 package com.nhnacademy.marketgg.server.dto.response.order;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;

--- a/src/main/java/com/nhnacademy/marketgg/server/service/order/OrderService.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/service/order/OrderService.java
@@ -111,4 +111,12 @@ public interface OrderService {
         return Long.valueOf(orderId.substring(orderId.indexOf("_") + 1));
     }
 
+    default String attachPrefix(final Long orderId) {
+        return "GGORDER_" + orderId;
+    }
+
+    default Long detachPrefix(final String orderId) {
+        return Long.valueOf(orderId.substring(orderId.indexOf("_") + 1));
+    }
+
 }

--- a/src/main/java/com/nhnacademy/marketgg/server/service/order/OrderService.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/service/order/OrderService.java
@@ -111,12 +111,4 @@ public interface OrderService {
         return Long.valueOf(orderId.substring(orderId.indexOf("_") + 1));
     }
 
-    default String attachPrefix(final Long orderId) {
-        return "GGORDER_" + orderId;
-    }
-
-    default Long detachPrefix(final String orderId) {
-        return Long.valueOf(orderId.substring(orderId.indexOf("_") + 1));
-    }
-
 }

--- a/src/main/java/com/nhnacademy/marketgg/server/service/payment/PaymentService.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/service/payment/PaymentService.java
@@ -13,7 +13,6 @@ import com.nhnacademy.marketgg.server.constant.payment.SettlementStatus;
 import com.nhnacademy.marketgg.server.dto.payment.PaymentResponse;
 import com.nhnacademy.marketgg.server.dto.payment.request.PaymentCancelRequest;
 import com.nhnacademy.marketgg.server.dto.payment.request.PaymentConfirmRequest;
-import com.nhnacademy.marketgg.server.dto.payment.request.PaymentVerifyRequest;
 import com.nhnacademy.marketgg.server.dto.payment.request.VirtualAccountCreateRequest;
 import com.nhnacademy.marketgg.server.dto.payment.request.VirtualAccountDepositRequest;
 import com.nhnacademy.marketgg.server.dto.payment.result.CardPaymentResult;
@@ -56,12 +55,20 @@ public interface PaymentService {
     PaymentResponse pay(final PaymentConfirmRequest paymentRequest);
 
     /**
+     * 승인된 결제를 결제키로 조회합니다.
+     *
+     * @param paymentKey     - 결제 건에 대한 고유 키 값
+     * @return paymentRequest - 상세 결제 내역 데이터
+     */
+    PaymentResponse retrievePayment(final String paymentKey);
+
+    /**
      * 결제 수단이 가상계좌인 경우, 가상계좌 발급을 요청합니다.
      *
      * @param virtualAccountRequest - 가상계좌 발급을 위한 요청 데이터가 담겨있는 객체
      * @return 발급한 가상계좌 데이터를 포함한 결과 데이터
      */
-    PaymentResponse createVirtualAccounts(final VirtualAccountCreateRequest virtualAccountRequest);
+    void createVirtualAccounts(final VirtualAccountCreateRequest virtualAccountRequest);
 
     /**
      * 회원이 주문한 건에 대해 가상계좌에 입금했을 때 결제 승인 처리를 수행합니다.

--- a/src/main/java/com/nhnacademy/marketgg/server/service/payment/TossPaymentService.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/service/payment/TossPaymentService.java
@@ -123,12 +123,31 @@ public class TossPaymentService implements PaymentService {
     /**
      * {@inheritDoc}
      *
+     * @param paymentKey - 결제 건에 대한 고유 키 값
+     * @return 결제한 데이터에 대한 응답 결과 데이터를 포함한 {@link PaymentResponse}
+     */
+    @Override
+    public PaymentResponse retrievePayment(String paymentKey) {
+        ResponseEntity<String> response = paymentAdapter.retrievePayment(paymentKey);
+
+        PaymentResponse paymentResponse;
+        try {
+            paymentResponse = objectMapper.readValue(response.getBody(), PaymentResponse.class);
+        } catch (JsonProcessingException ex) {
+            throw new UncheckedIOException(ex);
+        }
+
+        return paymentResponse;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
      * @param virtualAccountRequest - 가상계좌 발급을 위한 요청 데이터가 담겨있는 객체
      * @return 결제 요청 데이터에 대한 응답 결과 데이터를 포함한 {@link PaymentResponse}
      */
     @Override
-    public PaymentResponse createVirtualAccounts(VirtualAccountCreateRequest virtualAccountRequest) {
-        return null;
+    public void createVirtualAccounts(VirtualAccountCreateRequest virtualAccountRequest) {
     }
 
     /**
@@ -138,7 +157,6 @@ public class TossPaymentService implements PaymentService {
      */
     @Override
     public void putMoneyInVirtualAccount(VirtualAccountDepositRequest virtualAccountRequest) {
-        // STUB: 로직 수정 중
     }
 
     /**
@@ -149,7 +167,7 @@ public class TossPaymentService implements PaymentService {
      */
     @Override
     public void cancelPayment(final String paymentKey, final PaymentCancelRequest paymentRequest) {
-        ResponseEntity<String> response = paymentAdapter.cancel(paymentKey, paymentRequest);
+        paymentAdapter.cancel(paymentKey, paymentRequest);
 
         Payment foundPayment = paymentRepository.findByPaymentKey(paymentKey)
                                                 .orElseThrow(PaymentNotFoundException::new);

--- a/src/test/java/com/nhnacademy/marketgg/server/controller/payment/PaymentControllerTest.java
+++ b/src/test/java/com/nhnacademy/marketgg/server/controller/payment/PaymentControllerTest.java
@@ -1,0 +1,142 @@
+package com.nhnacademy.marketgg.server.controller.payment;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nhnacademy.marketgg.server.dto.payment.PaymentResponse;
+import com.nhnacademy.marketgg.server.dto.payment.request.PaymentCancelRequest;
+import com.nhnacademy.marketgg.server.dto.payment.request.PaymentConfirmRequest;
+import com.nhnacademy.marketgg.server.dto.payment.request.VirtualAccountCreateRequest;
+import com.nhnacademy.marketgg.server.dto.payment.request.VirtualAccountDepositRequest;
+import com.nhnacademy.marketgg.server.dto.response.order.OrderToPayment;
+import com.nhnacademy.marketgg.server.dummy.PaymentDummy;
+import com.nhnacademy.marketgg.server.service.payment.PaymentService;
+import java.util.function.BooleanSupplier;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebMvcTest(PaymentController.class)
+class PaymentControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    PaymentService paymentService;
+
+    @BeforeEach
+    void setUp(WebApplicationContext wac) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+                                      .alwaysDo(print())
+                                      .build();
+    }
+
+    @Test
+    @DisplayName("결제 검증 요청")
+    void testVerifyRequest() throws Exception {
+        BooleanSupplier supplier = spy(BooleanSupplier.class);
+        given(paymentService.verifyRequest(any(OrderToPayment.class)))
+                  .willReturn(supplier);
+        given(supplier.getAsBoolean()).willReturn(true);
+
+        mockMvc.perform(post("/payments/verify")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(PaymentDummy.getOrderToPayment())))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.success", Matchers.equalTo(true)));
+
+        then(paymentService).should(times(1))
+                            .verifyRequest(any(OrderToPayment.class));
+    }
+
+    @Test
+    @DisplayName("결제 승인 요청")
+    void testConfirmPayment() throws Exception {
+        PaymentResponse spy = spy(PaymentResponse.class);
+        given(paymentService.pay(any(PaymentConfirmRequest.class)))
+                  .willReturn(spy);
+
+        // ObjectMapper 로 필드 접근 시 접근 지정자를 ANY 로 설정하면 private 에도 접근 가능
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+        mockMvc.perform(post("/payments/confirm")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(PaymentDummy.getPaymentConfirmRequest())))
+               .andExpect(status().isCreated());
+
+        then(paymentService).should(times(1))
+                            .pay(any(PaymentConfirmRequest.class));
+    }
+
+    @Test
+    @DisplayName("가상계좌 발급 요청")
+    void testCreateVirtualAccounts() throws Exception {
+        willDoNothing().given(paymentService).createVirtualAccounts(any(VirtualAccountCreateRequest.class));
+
+        // ObjectMapper 로 필드 접근 시 접근 지정자를 ANY 로 설정하면 private 에도 접근 가능
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+        mockMvc.perform(post("/payments/virtual-accounts")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(PaymentDummy.getVirtualAccountCreateRequest())))
+               .andExpect(status().isCreated());
+
+        then(paymentService).should(times(1))
+                            .createVirtualAccounts(any(VirtualAccountCreateRequest.class));
+    }
+
+    @Test
+    @DisplayName("발급한 가상계좌 입금 확인")
+    void testPutMoneyInVirtualAccount() throws Exception {
+        willDoNothing().given(paymentService).putMoneyInVirtualAccount(any(VirtualAccountDepositRequest.class));
+
+        mockMvc.perform(post("/payments/virtual-accounts/deposit")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(PaymentDummy.getVirtualAccountDepositRequest())))
+               .andExpect(status().isOk());
+
+        then(paymentService).should(times(1))
+                            .putMoneyInVirtualAccount(any(VirtualAccountDepositRequest.class));
+    }
+
+    @Test
+    @DisplayName("결제 취소 요청")
+    void testCancelPayment() throws Exception {
+        willDoNothing().given(paymentService).cancelPayment(anyString(), any(PaymentCancelRequest.class));
+
+        String paymentKey = PaymentDummy.getPaymentConfirmRequest().getPaymentKey();
+        this.mockMvc.perform(post("/payments/" + paymentKey + "/cancel")
+                                 .contentType(MediaType.APPLICATION_JSON)
+                                 .content(objectMapper.writeValueAsString(PaymentDummy.getPaymentCancelRequest())))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success", Matchers.equalTo(true)));
+
+        then(paymentService).should(times(1))
+                            .cancelPayment(anyString(), any(PaymentCancelRequest.class));
+    }
+
+}

--- a/src/test/java/com/nhnacademy/marketgg/server/dummy/PaymentDummy.java
+++ b/src/test/java/com/nhnacademy/marketgg/server/dummy/PaymentDummy.java
@@ -1,0 +1,113 @@
+package com.nhnacademy.marketgg.server.dummy;
+
+import com.nhnacademy.marketgg.server.dto.payment.PaymentResponse;
+import com.nhnacademy.marketgg.server.dto.payment.request.PaymentCancelRequest;
+import com.nhnacademy.marketgg.server.dto.payment.request.PaymentConfirmRequest;
+import com.nhnacademy.marketgg.server.dto.payment.request.VirtualAccountCreateRequest;
+import com.nhnacademy.marketgg.server.dto.payment.request.VirtualAccountDepositRequest;
+import com.nhnacademy.marketgg.server.dto.payment.result.CardPaymentResult;
+import com.nhnacademy.marketgg.server.dto.payment.result.Receipt;
+import com.nhnacademy.marketgg.server.dto.response.order.OrderToPayment;
+import com.nhnacademy.marketgg.server.entity.payment.Payment;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class PaymentDummy {
+
+    public static final String PAYMENT_KEY = "EAK6k75XwlOyL0qZ4G1VOP4xk47qOroWb2MQYgmBDPdR9pxz";
+
+    public static OrderToPayment getOrderToPayment() {
+        return new OrderToPayment("GGORDER_1", "orderName", "강태풍",
+                                  "strong.storm@gmail.com", 30_000L, 1L,
+                                  2_000, 300);
+    }
+
+    public static PaymentConfirmRequest getPaymentConfirmRequest() {
+        return new PaymentConfirmRequest("GGORDER_1", PAYMENT_KEY, 3_200L);
+    }
+
+    public static PaymentCancelRequest getPaymentCancelRequest() {
+        return new PaymentCancelRequest("단순 변심", "신한", "110377904929", "강태풍");
+    }
+
+    public static Payment createPayment() {
+        return Payment.builder()
+                      .build();
+    }
+
+    public static PaymentConfirmRequest createPaymentConfirmRequest() {
+        return new PaymentConfirmRequest("GGORDER_1", PAYMENT_KEY, 75_600L);
+    }
+
+    public static VirtualAccountCreateRequest getVirtualAccountCreateRequest() {
+        return new VirtualAccountCreateRequest(75_600L, "신한", "강태풍",
+                                               "GGORDER_1", "[프렙] 쉬림프 로제 리조또 외 3건", 6);
+    }
+
+    public static VirtualAccountDepositRequest getVirtualAccountDepositRequest() {
+        return new VirtualAccountDepositRequest(LocalDateTime.parse("2022-01-01T00:00:00.000"),
+                                                "AQItPnF1QIJ_hQ1vt4BnI", "DONE",
+                                                "9FF15E1A29D0E77C218F57262BFA4986", "GGORDER_1");
+    }
+
+    public static PaymentResponse createPaymentResponse(String method) {
+        PaymentResponse paymentResponse = new PaymentResponse();
+        ReflectionTestUtils.setField(paymentResponse, "paymentKey", PAYMENT_KEY);
+        ReflectionTestUtils.setField(paymentResponse, "orderId", "GGORDER_1");
+        ReflectionTestUtils.setField(paymentResponse, "orderName", "[프렙] 쉬림프 로제 리조또 외 3건");
+        ReflectionTestUtils.setField(paymentResponse, "status", "DONE");
+        ReflectionTestUtils.setField(paymentResponse, "transactionKey", "0A25AEB83EB828C7CBDB3E0C97834557");
+        ReflectionTestUtils.setField(paymentResponse, "requestedAt", "2022-01-01T00:00:00+09:00");
+        ReflectionTestUtils.setField(paymentResponse, "approvedAt", "2022-01-01T00:00:00+09:00");
+        ReflectionTestUtils.setField(paymentResponse, "totalAmount", 75_600L);
+        ReflectionTestUtils.setField(paymentResponse, "balanceAmount", 100L);
+        ReflectionTestUtils.setField(paymentResponse, "method", Optional.ofNullable(method).orElse("카드"));
+        // ReflectionTestUtils.setField(paymentResponse, "card", getCardPaymentResult());
+
+        return paymentResponse;
+    }
+
+    private static CardPaymentResult getCardPaymentResult() {
+        CardPaymentResult result = new CardPaymentResult();
+        ReflectionTestUtils.setField(result, "amount", 75_600L);
+        ReflectionTestUtils.setField(result, "companyCode", "신한");
+        ReflectionTestUtils.setField(result, "number", "42215500****581*");
+        ReflectionTestUtils.setField(result, "cardType", "신용");
+        ReflectionTestUtils.setField(result, "ownerType", "개인");
+        ReflectionTestUtils.setField(result, "receiptUrl",
+                                     "https://dashboard.tosspayments.com/sales-slip?transactionId=v%2F0NtjvAdMVLEtqHnVUFzF6UozHOy5iHiaKp7u%2FrARSyQKnU6qMgnhS%2BBJ5evY%2BY&ref=PX");
+        ReflectionTestUtils.setField(result, "acquireStatus", "READY");
+
+        return result;
+    }
+
+    private static Receipt getReceipt() {
+        Receipt receipt = new Receipt();
+        ReflectionTestUtils.setField(receipt, "url",
+                                     "https://dashboard.tosspayments.com/sales-slip?transactionId=v%2F0NtjvAdMVLEtqHnVUFzF6UozHOy5iHiaKp7u%2FrARSyQKnU6qMgnhS%2BBJ5evY%2BY&ref=PX");
+
+        return receipt;
+    }
+
+    public static String cardResult() {
+        return "\"card\":{\"company\":\"신한\",\"number\":\"42215500****581*\",\"installmentPlanMonths\":0,\"isInterestFree\":false,\"interestPayer\":null,\"approveNo\":\"00000000\",\"useCardPoint\":false,\"cardType\":\"신용\",\"ownerType\":\"개인\",\"acquireStatus\":\"READY\",\"receiptUrl\":\"https://dashboard.tosspayments.com/sales-slip?transactionId=v%2F0NtjvAdMVLEtqHnVUFzF6UozHOy5iHiaKp7u%2FrARSyQKnU6qMgnhS%2BBJ5evY%2BY&ref=PX\",\"amount\":200},\"virtualAccount\":null,\"transfer\":null,\"mobilePhone\":null,";
+    }
+
+    public static String getPaymentResponse(String paymentTypeResult) {
+        return "{\"mId\":\"tvivarepublica\",\"transactionKey\":\"0A25AEB83EB828C7CBDB3E0C97834557\"," +
+            "\"lastTransactionKey\":\"0A25AEB83EB828C7CBDB3E0C97834557\"," +
+            "\"paymentKey\":\"5zJ4xY7m0kODnyRpQWGrNDLByYW0g3Kwv1M9ENjbeoPaZdL6\"," +
+            "\"orderId\":\"GGORDER_2\",\"orderName\":\"[KF365]아보카도200g(1걔)외2건\",\"status\":\"DONE\"," +
+            "\"requestedAt\":\"2022-08-11T01:12:54+09:00\",\"approvedAt\":\"2022-08-11T01:13:18+09:00\"," +
+            "\"useEscrow\":false,\"cultureExpense\":false," +
+            paymentTypeResult +
+            "\"giftCertificate\":null,\"cashReceipt\":null,\"discount\":null,\"cancels\":null," +
+            "\"secret\":\"ps_5GePWvyJnrK24lwpZyqVgLzN97Eo\",\"type\":\"NORMAL\",\"easyPay\":null,\"country\":\"KR\"," +
+            "\"failure\":null," +
+            "\"receipt\":{\"url\":\"https://dashboard.tosspayments.com/sales-slip?transactionId=duOfMjWI%2BxoZzSJ5VRibnUDEDnIUwV4tHtum0QzTA5nD1wiIrfzZXB5kXkjm4VD5&ref=PX\"},\"checkout\":{\"url\":\"https://api.tosspayments.com/v1/payments/5zJ4xY7m0kODnyRpQWGrNDLByYW0g3Kwv1M9ENjbeoPaZdL6/checkout\"}," +
+            "\"currency\":\"KRW\",\"totalAmount\":200,\"balanceAmount\":200,\"suppliedAmount\":182," +
+            "\"vat\":18,\"taxFreeAmount\":0,\"method\":\"카드\",\"version\":\"2022-07-27\"}";
+    }
+
+}

--- a/src/test/java/com/nhnacademy/marketgg/server/service/payment/TossPaymentServiceTest.java
+++ b/src/test/java/com/nhnacademy/marketgg/server/service/payment/TossPaymentServiceTest.java
@@ -1,0 +1,182 @@
+package com.nhnacademy.marketgg.server.service.payment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.exc.InputCoercionException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nhnacademy.marketgg.server.constant.payment.PaymentType;
+import com.nhnacademy.marketgg.server.dto.payment.PaymentResponse;
+import com.nhnacademy.marketgg.server.dto.payment.request.PaymentCancelRequest;
+import com.nhnacademy.marketgg.server.dto.payment.request.PaymentConfirmRequest;
+import com.nhnacademy.marketgg.server.dto.response.order.OrderToPayment;
+import com.nhnacademy.marketgg.server.dummy.Dummy;
+import com.nhnacademy.marketgg.server.dummy.PaymentDummy;
+import com.nhnacademy.marketgg.server.entity.Order;
+import com.nhnacademy.marketgg.server.entity.payment.Payment;
+import com.nhnacademy.marketgg.server.repository.order.OrderRepository;
+import com.nhnacademy.marketgg.server.repository.payment.CardPaymentRepository;
+import com.nhnacademy.marketgg.server.repository.payment.PaymentAdapter;
+import com.nhnacademy.marketgg.server.repository.payment.PaymentRepository;
+import com.nhnacademy.marketgg.server.service.order.DefaultOrderService;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("test")
+@ExtendWith(MockitoExtension.class)
+@Transactional
+class TossPaymentServiceTest {
+
+    @InjectMocks
+    TossPaymentService paymentService;
+
+    @Mock
+    DefaultOrderService orderService;
+
+    @Mock
+    OrderRepository orderRepository;
+
+    @Mock
+    PaymentRepository paymentRepository;
+
+    @Mock
+    PaymentAdapter paymentAdapter;
+
+    @Mock
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("결제 요청 검증")
+    void testVerifyRequest() {
+        Long orderId = 1L;
+        BDDMockito.given(orderService.detachPrefix(anyString())).willReturn(orderId);
+
+        Order spyOrder = spy(Dummy.getDummyOrder());
+        BDDMockito.given(orderRepository.findById(orderId)).willReturn(Optional.of(spyOrder));
+
+        OrderToPayment dummyOrderToPayment = PaymentDummy.getOrderToPayment();
+        BDDMockito.given(spyOrder.getTotalAmount()).willReturn(dummyOrderToPayment.getTotalAmount());
+
+        BooleanSupplier supplier = paymentService.verifyRequest(dummyOrderToPayment);
+
+        assertThat(supplier.getAsBoolean()).isTrue();
+    }
+
+    @Test
+    @DisplayName("결제 수단에 따른 결제 승인")
+    void testPay() throws JsonProcessingException {
+        PaymentResponse spyPaymentResponse = spy(PaymentDummy.createPaymentResponse(PaymentType.CARD.getName()));
+        BDDMockito.doReturn(spyPaymentResponse).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
+
+        BDDMockito.given(objectMapper.writeValueAsString(spyPaymentResponse))
+                  .willReturn(PaymentDummy.getPaymentResponse(PaymentDummy.cardResult()));
+
+        String spyString = objectMapper.writeValueAsString(spyPaymentResponse);
+        ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(spyString));
+
+        BDDMockito.given(paymentAdapter.confirm(any(PaymentConfirmRequest.class))).willReturn(response);
+        BDDMockito.given(response.getBody()).willReturn(spyString);
+
+        PaymentConfirmRequest dummyPaymentRequest = spy(PaymentDummy.getPaymentConfirmRequest());
+
+        Order spyOrder = spy(Dummy.getDummyOrder());
+        BDDMockito.given(orderRepository.findById(anyLong())).willReturn(Optional.of(spyOrder));
+        BDDMockito.given(paymentRepository.save(any(Payment.class))).willReturn(any(Payment.class));
+
+        PaymentResponse paymentResponse = paymentService.pay(dummyPaymentRequest);
+
+        assertThat(paymentResponse).isNotNull();
+
+        verify(objectMapper, times(1)).readValue(anyString(), eq(PaymentResponse.class));
+    }
+
+    @Test
+    @DisplayName("결제 승인 도중 파싱 오류 시 예외 처리 여부")
+    void testPayInTheMiddleOfThrowException() throws JsonProcessingException {
+        BDDMockito.doThrow(JsonProcessingException.class).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
+
+        ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(""));
+
+        BDDMockito.given(paymentAdapter.confirm(any(PaymentConfirmRequest.class))).willReturn(response);
+        BDDMockito.given(response.getBody()).willReturn("");
+
+        PaymentConfirmRequest dummyPaymentRequest = spy(PaymentDummy.getPaymentConfirmRequest());
+
+        assertThatThrownBy(() -> paymentService.pay(dummyPaymentRequest)).isInstanceOf(UncheckedIOException.class);
+    }
+
+    @Test
+    @DisplayName("결제된 건에 대하여 결제 조회")
+    void testRetrievePayment() throws JsonProcessingException {
+        PaymentResponse spyPaymentResponse = spy(PaymentDummy.createPaymentResponse(PaymentType.CARD.getName()));
+        BDDMockito.doReturn(spyPaymentResponse).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
+
+        BDDMockito.given(objectMapper.writeValueAsString(spyPaymentResponse))
+                  .willReturn(PaymentDummy.getPaymentResponse(PaymentDummy.cardResult()));
+
+        String spyString = objectMapper.writeValueAsString(spyPaymentResponse);
+        ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(spyString));
+
+        BDDMockito.given(paymentAdapter.retrievePayment(anyString())).willReturn(response);
+        BDDMockito.given(response.getBody()).willReturn(spyString);
+
+        PaymentResponse paymentResponse = paymentService.retrievePayment(PaymentDummy.PAYMENT_KEY);
+
+        assertThat(paymentResponse).isNotNull();
+
+        verify(objectMapper, times(1)).readValue(anyString(), eq(PaymentResponse.class));
+    }
+
+    @Test
+    @DisplayName("결제 승인 도중 파싱 오류 시 예외 처리 여부")
+    void testRetrievePaymentInTheMiddleOfThrowException() throws JsonProcessingException {
+        BDDMockito.doThrow(JsonProcessingException.class).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
+
+        ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(""));
+
+        BDDMockito.given(paymentAdapter.retrievePayment(anyString())).willReturn(response);
+        BDDMockito.given(response.getBody()).willReturn("");
+
+        assertThatThrownBy(() -> paymentService.retrievePayment(PaymentDummy.PAYMENT_KEY)).isInstanceOf(UncheckedIOException.class);
+    }
+
+//     @Test
+//     void createVirtualAccounts() {
+//     }
+//
+//     @Test
+//     void putMoneyInVirtualAccount() {
+//     }
+
+    @Test
+    void cancelPayment() throws JsonProcessingException {
+        ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(""));
+        BDDMockito.given(paymentAdapter.cancel(anyString(), any(PaymentCancelRequest.class))).willReturn(response);
+
+        Payment payment = PaymentDummy.createPayment();
+        BDDMockito.given(paymentRepository.findByPaymentKey(anyString())).willReturn(Optional.of(payment));
+
+        paymentService.cancelPayment(PaymentDummy.PAYMENT_KEY, PaymentDummy.getPaymentCancelRequest());
+    }
+
+}

--- a/src/test/java/com/nhnacademy/marketgg/server/service/payment/TossPaymentServiceTest.java
+++ b/src/test/java/com/nhnacademy/marketgg/server/service/payment/TossPaymentServiceTest.java
@@ -6,25 +6,27 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.exc.InputCoercionException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nhnacademy.marketgg.server.constant.payment.PaymentType;
 import com.nhnacademy.marketgg.server.dto.payment.PaymentResponse;
 import com.nhnacademy.marketgg.server.dto.payment.request.PaymentCancelRequest;
 import com.nhnacademy.marketgg.server.dto.payment.request.PaymentConfirmRequest;
+import com.nhnacademy.marketgg.server.dto.payment.request.VirtualAccountCreateRequest;
 import com.nhnacademy.marketgg.server.dto.response.order.OrderToPayment;
 import com.nhnacademy.marketgg.server.dummy.Dummy;
 import com.nhnacademy.marketgg.server.dummy.PaymentDummy;
 import com.nhnacademy.marketgg.server.entity.Order;
 import com.nhnacademy.marketgg.server.entity.payment.Payment;
 import com.nhnacademy.marketgg.server.repository.order.OrderRepository;
-import com.nhnacademy.marketgg.server.repository.payment.CardPaymentRepository;
 import com.nhnacademy.marketgg.server.repository.payment.PaymentAdapter;
 import com.nhnacademy.marketgg.server.repository.payment.PaymentRepository;
 import com.nhnacademy.marketgg.server.service.order.DefaultOrderService;
@@ -34,7 +36,6 @@ import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -69,13 +70,13 @@ class TossPaymentServiceTest {
     @DisplayName("결제 요청 검증")
     void testVerifyRequest() {
         Long orderId = 1L;
-        BDDMockito.given(orderService.detachPrefix(anyString())).willReturn(orderId);
+        given(orderService.detachPrefix(anyString())).willReturn(orderId);
 
         Order spyOrder = spy(Dummy.getDummyOrder());
-        BDDMockito.given(orderRepository.findById(orderId)).willReturn(Optional.of(spyOrder));
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(spyOrder));
 
         OrderToPayment dummyOrderToPayment = PaymentDummy.getOrderToPayment();
-        BDDMockito.given(spyOrder.getTotalAmount()).willReturn(dummyOrderToPayment.getTotalAmount());
+        given(spyOrder.getTotalAmount()).willReturn(dummyOrderToPayment.getTotalAmount());
 
         BooleanSupplier supplier = paymentService.verifyRequest(dummyOrderToPayment);
 
@@ -86,22 +87,22 @@ class TossPaymentServiceTest {
     @DisplayName("결제 수단에 따른 결제 승인")
     void testPay() throws JsonProcessingException {
         PaymentResponse spyPaymentResponse = spy(PaymentDummy.createPaymentResponse(PaymentType.CARD.getName()));
-        BDDMockito.doReturn(spyPaymentResponse).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
+        doReturn(spyPaymentResponse).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
 
-        BDDMockito.given(objectMapper.writeValueAsString(spyPaymentResponse))
+        given(objectMapper.writeValueAsString(spyPaymentResponse))
                   .willReturn(PaymentDummy.getPaymentResponse(PaymentDummy.cardResult()));
 
         String spyString = objectMapper.writeValueAsString(spyPaymentResponse);
         ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(spyString));
 
-        BDDMockito.given(paymentAdapter.confirm(any(PaymentConfirmRequest.class))).willReturn(response);
-        BDDMockito.given(response.getBody()).willReturn(spyString);
+        given(paymentAdapter.confirm(any(PaymentConfirmRequest.class))).willReturn(response);
+        given(response.getBody()).willReturn(spyString);
 
         PaymentConfirmRequest dummyPaymentRequest = spy(PaymentDummy.getPaymentConfirmRequest());
 
         Order spyOrder = spy(Dummy.getDummyOrder());
-        BDDMockito.given(orderRepository.findById(anyLong())).willReturn(Optional.of(spyOrder));
-        BDDMockito.given(paymentRepository.save(any(Payment.class))).willReturn(any(Payment.class));
+        given(orderRepository.findById(anyLong())).willReturn(Optional.of(spyOrder));
+        given(paymentRepository.save(any(Payment.class))).willReturn(any(Payment.class));
 
         PaymentResponse paymentResponse = paymentService.pay(dummyPaymentRequest);
 
@@ -113,12 +114,14 @@ class TossPaymentServiceTest {
     @Test
     @DisplayName("결제 승인 도중 파싱 오류 시 예외 처리 여부")
     void testPayInTheMiddleOfThrowException() throws JsonProcessingException {
-        BDDMockito.doThrow(JsonProcessingException.class).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
+        doThrow(JsonProcessingException.class)
+                  .when(objectMapper)
+                  .readValue(anyString(), eq(PaymentResponse.class));
 
         ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(""));
 
-        BDDMockito.given(paymentAdapter.confirm(any(PaymentConfirmRequest.class))).willReturn(response);
-        BDDMockito.given(response.getBody()).willReturn("");
+        given(paymentAdapter.confirm(any(PaymentConfirmRequest.class))).willReturn(response);
+        given(response.getBody()).willReturn("");
 
         PaymentConfirmRequest dummyPaymentRequest = spy(PaymentDummy.getPaymentConfirmRequest());
 
@@ -129,16 +132,16 @@ class TossPaymentServiceTest {
     @DisplayName("결제된 건에 대하여 결제 조회")
     void testRetrievePayment() throws JsonProcessingException {
         PaymentResponse spyPaymentResponse = spy(PaymentDummy.createPaymentResponse(PaymentType.CARD.getName()));
-        BDDMockito.doReturn(spyPaymentResponse).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
+        doReturn(spyPaymentResponse).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
 
-        BDDMockito.given(objectMapper.writeValueAsString(spyPaymentResponse))
+        given(objectMapper.writeValueAsString(spyPaymentResponse))
                   .willReturn(PaymentDummy.getPaymentResponse(PaymentDummy.cardResult()));
 
         String spyString = objectMapper.writeValueAsString(spyPaymentResponse);
         ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(spyString));
 
-        BDDMockito.given(paymentAdapter.retrievePayment(anyString())).willReturn(response);
-        BDDMockito.given(response.getBody()).willReturn(spyString);
+        given(paymentAdapter.retrievePayment(anyString())).willReturn(response);
+        given(response.getBody()).willReturn(spyString);
 
         PaymentResponse paymentResponse = paymentService.retrievePayment(PaymentDummy.PAYMENT_KEY);
 
@@ -150,31 +153,39 @@ class TossPaymentServiceTest {
     @Test
     @DisplayName("결제 승인 도중 파싱 오류 시 예외 처리 여부")
     void testRetrievePaymentInTheMiddleOfThrowException() throws JsonProcessingException {
-        BDDMockito.doThrow(JsonProcessingException.class).when(objectMapper).readValue(anyString(), eq(PaymentResponse.class));
+        doThrow(JsonProcessingException.class)
+                  .when(objectMapper)
+                  .readValue(anyString(), eq(PaymentResponse.class));
 
         ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(""));
 
-        BDDMockito.given(paymentAdapter.retrievePayment(anyString())).willReturn(response);
-        BDDMockito.given(response.getBody()).willReturn("");
+        given(paymentAdapter.retrievePayment(anyString())).willReturn(response);
+        given(response.getBody()).willReturn("");
 
-        assertThatThrownBy(() -> paymentService.retrievePayment(PaymentDummy.PAYMENT_KEY)).isInstanceOf(UncheckedIOException.class);
+        assertThatThrownBy(() -> paymentService.retrievePayment(PaymentDummy.PAYMENT_KEY)).isInstanceOf(
+            UncheckedIOException.class);
     }
 
-//     @Test
-//     void createVirtualAccounts() {
-//     }
-//
-//     @Test
-//     void putMoneyInVirtualAccount() {
-//     }
+    @Test
+    @DisplayName("가상계좌 발급")
+    void createVirtualAccounts() {
+        paymentService.createVirtualAccounts(PaymentDummy.getVirtualAccountCreateRequest());
+    }
 
     @Test
+    @DisplayName("발급된 가상계좌 입금 확인")
+    void putMoneyInVirtualAccount() {
+        paymentService.putMoneyInVirtualAccount(PaymentDummy.getVirtualAccountDepositRequest());
+    }
+
+    @Test
+    @DisplayName("승인된 결제 취소")
     void cancelPayment() throws JsonProcessingException {
         ResponseEntity<String> response = spy(ResponseEntity.ok().contentType(APPLICATION_JSON).body(""));
-        BDDMockito.given(paymentAdapter.cancel(anyString(), any(PaymentCancelRequest.class))).willReturn(response);
+        given(paymentAdapter.cancel(anyString(), any(PaymentCancelRequest.class))).willReturn(response);
 
         Payment payment = PaymentDummy.createPayment();
-        BDDMockito.given(paymentRepository.findByPaymentKey(anyString())).willReturn(Optional.of(payment));
+        given(paymentRepository.findByPaymentKey(anyString())).willReturn(Optional.of(payment));
 
         paymentService.cancelPayment(PaymentDummy.PAYMENT_KEY, PaymentDummy.getPaymentCancelRequest());
     }


### PR DESCRIPTION
## 개요

- Closes #272 
- 결제 서비스 레이어 테스트 코드 작성 및 구현 내용 보완

## 작업 사항

- [x] 주문 서비스 중복 메서드 삭제
- [x] 사용하지 않는 결제 수단(가상계좌) 정리
- [x] 결제키를 통한 결제 내역 조회 기능 추가 (기존 누락)
- [x] 어댑터 API 호출 시 Raw type 제거
- [x] 결제 응답 객체 문서화
- [x] 충돌 방지를 위한 결제 관련 더미 클래스 추가
- [x] 결제 컨트롤러 테스트 커버리지 보완
- [x] 결제 서비스 테스트 코드 작성
